### PR TITLE
Feat: portal API updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /data/
-
+__pycache__/
 .vscode

--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ This capsule builds a reconstruction snapshot for one exaSPIM subject and publis
 It performs the following workflow:
 - Parses the subject ID from a raw data asset URI.
 - Downloads published neuron reconstructions from the NMCP service in both spaces:
-  - CCF space: JSON and SWC
-  - Specimen space: JSON and SWC
-- Generates Neuroglancer precomputed skeleton outputs from downloaded JSON reconstructions.
+  - CCF space: legacy JSON and SWC
+  - Specimen space: legacy JSON and SWC
+- Downloads temporary portal-format JSON reconstructions in both spaces for precomputed generation.
+- Generates Neuroglancer precomputed skeleton outputs from staged portal-format JSON reconstructions.
 - Generates reconstruction metadata JSON files.
 - Uploads everything under `/results` to an S3 destination generated from the raw asset name and a destination bucket.
 
@@ -25,6 +26,7 @@ Arguments:
 - `<s3-destination-bucket>`: Destination bucket for final results (for example, `aind-open-data` or `s3://aind-open-data`).
 - `<fused-zarr-path>`: OME-Zarr group path used to derive specimen-space precomputed resolution and volume size, and to populate `data_description.source_data` with the top-level fused asset URI. Supported layouts include `s3://bucket/<asset>/fused.zarr` and `s3://bucket/<asset>/fusion/fused.zarr`.
 - `<processing.json path>`: Path to the processing.json file within the final processed reconstruction asset in CodeOcean, mounted to the capsule.
+- `NMCP_BASE_URL` (optional environment variable): Base URL for the NMCP portal instance. Defaults to `https://morphology.allenneuraldynamics.org`.
 - The reconstruction spreadsheet is always downloaded from Smartsheet at runtime.
 
 Example:
@@ -62,6 +64,10 @@ Main outputs:
 - `/results/quality_control.json`
 - `/results/data_description.json`
 - `/results/processing.json`
+
+Notes:
+- The archived JSON outputs under `/results/.../json` remain legacy JSON exports.
+- Portal-format JSON is staged in a temporary directory only for precomputed generation and is deleted before the script exits.
 
 ## Prerequisites
 

--- a/code/reconstruction_snapshot/download_neurons.py
+++ b/code/reconstruction_snapshot/download_neurons.py
@@ -2,10 +2,16 @@ import argparse
 import concurrent.futures as futures
 import logging
 import time
+from functools import partial
 from pathlib import Path
 from typing import Callable, Optional, Sequence
 
-from enums import ExportFormat, ReconstructionSpace
+from enums import (
+    ExportFormat,
+    ReconstructionSpace,
+    parse_export_format,
+    parse_reconstruction_space,
+)
 from nmcp_client import (
     QueryError,
     NmcpClientConfig,
@@ -16,14 +22,14 @@ from nmcp_client import (
 )
 
 
-DEFAULT_EXPORT_FORMAT = ExportFormat.JSON
+DEFAULT_EXPORT_FORMAT = ExportFormat.LEGACY_JSON
 
 
 def _select_download_fn(
     service: NmcpClient, export_format: ExportFormat
 ) -> Callable[..., object]:
-    if export_format is ExportFormat.JSON:
-        return service.download_json
+    if export_format in (ExportFormat.LEGACY_JSON, ExportFormat.PORTAL_JSON):
+        return partial(service.download_json, export_format=export_format)
     if export_format is ExportFormat.SWC:
         return service.download_swc
     raise ValueError(f"Unsupported export format: {export_format}")
@@ -106,32 +112,17 @@ def download_neurons(
 
 def _parse_export_format(value: str) -> ExportFormat:
     """
-    Argparse type that accepts either integer enum values (e.g. '0', '1')
-    or names (e.g. 'json', 'swc'), case-insensitive.
+    Argparse type that accepts integer enum values or stable CLI aliases.
     """
-    # Try int value
     try:
-        ivalue = int(value)
-        return ExportFormat(ivalue)
-    except (ValueError, KeyError):
-        pass
-
-    # Try name
-    try:
-        return ExportFormat[value.upper()]
-    except KeyError as exc:
-        # Helpful message
-        names = ", ".join(e.name.lower() for e in ExportFormat)
-        values = ", ".join(str(e.value) for e in ExportFormat)
-        raise argparse.ArgumentTypeError(
-            f"Invalid format '{value}'. Use one of names {{{names}}} "
-            f"or values {{{values}}}."
-        ) from exc
+        return parse_export_format(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(str(exc)) from exc
 
 
 def _parse_reconstruction_space(value: str) -> ReconstructionSpace:
     try:
-        return ReconstructionSpace.parse_name(value)
+        return parse_reconstruction_space(value)
     except ValueError as exc:
         raise argparse.ArgumentTypeError(str(exc)) from exc
 
@@ -150,8 +141,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "-f",
         "--format",
-        help="Export format (name or value, e.g. 'json', 'swc', or matching integer value).",
-        default=DEFAULT_EXPORT_FORMAT.name.lower(),
+        help=(
+            "Export format (alias or numeric value). "
+            "Supported aliases: json, legacy-json, portal-json, swc."
+        ),
+        default="json",
         type=_parse_export_format,
     )
     parser.add_argument(
@@ -159,7 +153,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--reconstruction-space",
         type=_parse_reconstruction_space,
         default=ReconstructionSpace.SPECIMEN,
-        help="Reconstruction space to download. Valid values: specimen, ccf.",
+        help="Reconstruction space to download. Supported aliases: specimen, atlas, ccf.",
     )
     parser.add_argument(
         "-o",

--- a/code/reconstruction_snapshot/enums.py
+++ b/code/reconstruction_snapshot/enums.py
@@ -1,24 +1,65 @@
 from __future__ import annotations
 
-from enum import IntEnum
+from nmcp import ExportFormat, ReconstructionSpace
 
 
-class ExportFormat(IntEnum):
-    SWC = 0
-    JSON = 1
+EXPORT_FORMAT_ALIASES: dict[str, ExportFormat] = {
+    "json": ExportFormat.LEGACY_JSON,
+    "legacy-json": ExportFormat.LEGACY_JSON,
+    "portal-json": ExportFormat.PORTAL_JSON,
+    "swc": ExportFormat.SWC,
+}
+
+RECONSTRUCTION_SPACE_ALIASES: dict[str, ReconstructionSpace] = {
+    "specimen": ReconstructionSpace.SPECIMEN,
+    "atlas": ReconstructionSpace.ATLAS,
+    "ccf": ReconstructionSpace.ATLAS,
+}
 
 
-class ReconstructionSpace(IntEnum):
-    SPECIMEN = 0
-    CCF = 1
+def parse_export_format(value: str) -> ExportFormat:
+    """Parse CLI export format values, including stable aliases."""
+    try:
+        return ExportFormat(int(value))
+    except (TypeError, ValueError):
+        pass
 
-    @classmethod
-    def parse_name(cls, value: str) -> "ReconstructionSpace":
-        normalized = value.strip().upper()
-        try:
-            return cls[normalized]
-        except KeyError as exc:
-            names = ", ".join(space.name.lower() for space in cls)
-            raise ValueError(
-                f"Invalid reconstruction space '{value}'. Use one of {{{names}}}."
-            ) from exc
+    normalized = value.strip().lower().replace("_", "-")
+
+    try:
+        return ExportFormat[normalized.upper().replace("-", "_")]
+    except KeyError:
+        pass
+
+    try:
+        return EXPORT_FORMAT_ALIASES[normalized]
+    except KeyError as exc:
+        names = ", ".join(sorted(EXPORT_FORMAT_ALIASES))
+        values = ", ".join(str(item.value) for item in ExportFormat)
+        raise ValueError(
+            f"Invalid format '{value}'. Use one of names {{{names}}} or values {{{values}}}."
+        ) from exc
+
+
+def parse_reconstruction_space(value: str) -> ReconstructionSpace:
+    """Parse CLI reconstruction-space values, including legacy aliases."""
+    try:
+        return ReconstructionSpace(int(value))
+    except (TypeError, ValueError):
+        pass
+
+    normalized = value.strip().lower().replace("_", "-")
+
+    try:
+        return ReconstructionSpace[normalized.upper().replace("-", "_")]
+    except KeyError:
+        pass
+
+    try:
+        return RECONSTRUCTION_SPACE_ALIASES[normalized]
+    except KeyError as exc:
+        names = ", ".join(sorted(RECONSTRUCTION_SPACE_ALIASES))
+        values = ", ".join(str(item.value) for item in ReconstructionSpace)
+        raise ValueError(
+            f"Invalid reconstruction space '{value}'. Use one of {{{names}}} or values {{{values}}}."
+        ) from exc

--- a/code/reconstruction_snapshot/nmcp_client.py
+++ b/code/reconstruction_snapshot/nmcp_client.py
@@ -14,7 +14,8 @@ from zip_utils import ZipExtractor, ZipExtractError
 
 
 FORMAT_SUFFIXES: Dict[ExportFormat, str] = {
-    ExportFormat.JSON: ".json",
+    ExportFormat.LEGACY_JSON: ".json",
+    ExportFormat.PORTAL_JSON: ".json",
     ExportFormat.SWC: ".swc",
 }
 
@@ -171,6 +172,7 @@ class NmcpClient:
         self,
         neuron: NeuronData,
         *,
+        export_format: ExportFormat = ExportFormat.LEGACY_JSON,
         reconstruction_space: ReconstructionSpace,
         output_path: Optional[Path | str] = None,
         attempts: int = 1,
@@ -188,9 +190,14 @@ class NmcpClient:
         Returns:
             dict: Parsed JSON payload.
         """
+        if export_format not in (ExportFormat.LEGACY_JSON, ExportFormat.PORTAL_JSON):
+            raise ValueError(
+                f"Unsupported JSON export format: {export_format}"
+            )
+
         json_text = self._download_text_payload(
             neuron,
-            ExportFormat.JSON,
+            export_format,
             reconstruction_space,
             output_path,
             attempts,

--- a/code/reconstruction_snapshot/write_precomputed.py
+++ b/code/reconstruction_snapshot/write_precomputed.py
@@ -126,7 +126,6 @@ def _scale_reconstruction_to_voxel_space(
 
     for node in nodes:
         if isinstance(node, dict):
-            print("scaling node")
             _scale_point_to_voxel_space(node, scale_um_xyz)
 
     return scaled

--- a/code/reconstruction_snapshot/write_precomputed.py
+++ b/code/reconstruction_snapshot/write_precomputed.py
@@ -1,14 +1,16 @@
 import argparse
-import glob
 import json
 from copy import deepcopy
 from pathlib import Path
+from typing import Optional, Sequence
 
 from cloudvolume import CloudVolume
-from precomputed import create_from_dict, create_from_json_files
+from nmcp import create_from_reconstruction
 
 
-def _load_dataset_zero_metadata(zarr_group_path: str) -> tuple[tuple[int, ...], list[float]]:
+def _load_dataset_zero_metadata(
+    zarr_group_path: str,
+) -> tuple[tuple[int, ...], list[float]]:
     try:
         import fsspec
         import zarr
@@ -41,7 +43,11 @@ def _load_dataset_zero_metadata(zarr_group_path: str) -> tuple[tuple[int, ...], 
 
         transform = None
         for item in dataset_zero.get("coordinateTransformations", []):
-            if isinstance(item, dict) and item.get("type") == "scale" and "scale" in item:
+            if (
+                isinstance(item, dict)
+                and item.get("type") == "scale"
+                and "scale" in item
+            ):
                 transform = item
                 break
 
@@ -80,7 +86,9 @@ def _shape_to_volume_size(shape: tuple[int, ...]) -> list[int]:
     return [int(shape[-1]), int(shape[-2]), int(shape[-3])]
 
 
-def _build_precomputed_info(volume_size_xyz: list[int], resolution_nm_xyz: list[float]) -> dict:
+def _build_precomputed_info(
+    volume_size_xyz: list[int], resolution_nm_xyz: list[float]
+) -> dict:
     info = CloudVolume.create_new_info(
         num_channels=1,
         layer_type="segmentation",
@@ -97,45 +105,62 @@ def _build_precomputed_info(volume_size_xyz: list[int], resolution_nm_xyz: list[
     return info
 
 
-def _scale_point_to_voxel_space(point: dict, scale_um_xyz: list[float]):
-    for axis, divisor in (("x", scale_um_xyz[0]), ("y", scale_um_xyz[1]), ("z", scale_um_xyz[2])):
+def _scale_point_to_voxel_space(point: dict, scale_um_xyz: list[float]) -> None:
+    for axis, divisor in (
+        ("x", scale_um_xyz[0]),
+        ("y", scale_um_xyz[1]),
+        ("z", scale_um_xyz[2]),
+    ):
         if axis in point and point[axis] is not None:
             point[axis] = float(point[axis]) / divisor
 
 
-def _scale_neuron_to_voxel_space(neuron: dict, scale_um_xyz: list[float]) -> dict:
-    scaled = deepcopy(neuron)
+def _scale_reconstruction_to_voxel_space(
+    reconstruction: dict, scale_um_xyz: list[float]
+) -> dict:
+    scaled = deepcopy(reconstruction)
 
-    soma = scaled.get("soma")
-    if isinstance(soma, dict):
-        _scale_point_to_voxel_space(soma, scale_um_xyz)
+    nodes = scaled.get("nodes")
+    if not isinstance(nodes, list):
+        raise ValueError("Portal reconstruction is missing a `nodes` list.")
 
-    for key in ("axon", "dendrite"):
-        points = scaled.get(key)
-        if isinstance(points, list):
-            for point in points:
-                if isinstance(point, dict):
-                    _scale_point_to_voxel_space(point, scale_um_xyz)
+    for node in nodes:
+        if isinstance(node, dict):
+            print("scaling node")
+            _scale_point_to_voxel_space(node, scale_um_xyz)
 
     return scaled
 
 
-def main():
-    """Convert JSON files to precomputed format and upload to S3."""
+def _load_portal_reconstruction(json_file: Path) -> dict:
+    with json_file.open() as f:
+        data = json.load(f)
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Portal reconstruction file {json_file} must contain a JSON object.")
+    if "neuron" not in data or "nodes" not in data:
+        raise ValueError(
+            f"Portal reconstruction file {json_file} must contain `neuron` and `nodes`."
+        )
+
+    return data
+
+
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="Convert JSON files to precomputed format and upload to S3"
+        description="Convert portal-format JSON files to precomputed format."
     )
     parser.add_argument(
         "--input-dir",
         type=str,
         required=True,
-        help="Input directory containing JSON files"
+        help="Input directory containing portal-format JSON files.",
     )
     parser.add_argument(
         "--output",
         type=str,
         required=True,
-        help="Output dir or S3 URI (e.g., s3://bucket-name/path)"
+        help="Output dir or S3 URI (e.g., s3://bucket-name/path).",
     )
     parser.add_argument(
         "--zarr-group",
@@ -144,27 +169,34 @@ def main():
         help=(
             "Optional path to an OME-Zarr group root (e.g., s3://bucket/path/to/group). "
             "When provided, dataset `0` metadata drives info resolution/volume size and "
-            "neuron coordinates are scaled to voxel space."
+            "portal node coordinates are scaled to voxel space."
         ),
     )
-    
-    args = parser.parse_args()
-    
-    # Find all JSON files in the input directory
+    return parser
+
+
+def main(cli_args: Optional[Sequence[str]] = None) -> None:
+    """Convert portal-format JSON files to precomputed format."""
+    parser = build_parser()
+    args = parser.parse_args(cli_args)
+
     input_path = Path(args.input_dir)
-    json_pattern = str(input_path / "*.json")
-    jsons = glob.glob(json_pattern, recursive=True)
-    
+    jsons = sorted(input_path.glob("*.json"))
+
     print(f"Found {len(jsons)} JSON files in {args.input_dir}")
-    print(f"Files: {jsons}")
-    
-    # Create precomputed format and upload to S3
-    info = None
+    print(f"Files: {[str(path) for path in jsons]}")
+
+    info: dict
+    scale_um_xyz: Optional[list[float]] = None
     if args.zarr_group:
         try:
             shape, scale_um_xyz = _load_dataset_zero_metadata(args.zarr_group)
             volume_size_xyz = _shape_to_volume_size(shape)
-            resolution_nm_xyz = [scale_um_xyz[0] * 1000.0, scale_um_xyz[1] * 1000.0, scale_um_xyz[2] * 1000.0]
+            resolution_nm_xyz = [
+                scale_um_xyz[0] * 1000.0,
+                scale_um_xyz[1] * 1000.0,
+                scale_um_xyz[2] * 1000.0,
+            ]
             info = _build_precomputed_info(volume_size_xyz, resolution_nm_xyz)
         except Exception as ex:
             raise SystemExit(
@@ -175,20 +207,27 @@ def main():
         print(f"Dataset `0` scale (um, x/y/z): {scale_um_xyz}")
         print(f"Derived precomputed resolution (nm, x/y/z): {resolution_nm_xyz}")
         print(f"Derived precomputed volume_size (x,y,z): {volume_size_xyz}")
-
     else:
-        # Assumes 10um CCFv3 space defaults
+        # Assumes 10um CCFv3 space defaults.
         volume_size_xyz = [1320, 800, 1140]
         resolution_nm_xyz = [10000, 10000, 10000]
         scale_um_xyz = [10, 10, 10]
         info = _build_precomputed_info(volume_size_xyz, resolution_nm_xyz)
-    
+
     for json_file in jsons:
-        with open(json_file) as f:
-            data = json.load(f)
-        neuron = data["neurons"][0]
-        scaled_neuron = _scale_neuron_to_voxel_space(neuron, scale_um_xyz)
-        create_from_dict(scaled_neuron, args.output, info)
+        reconstruction = _load_portal_reconstruction(json_file)
+        if scale_um_xyz is not None:
+            reconstruction = _scale_reconstruction_to_voxel_space(
+                reconstruction, scale_um_xyz
+            )
+
+        skeleton_id = create_from_reconstruction(
+            reconstruction, args.output, cloud_files_info=info
+        )
+        if skeleton_id is None:
+            raise RuntimeError(
+                f"Failed to generate precomputed data for portal reconstruction {json_file}."
+            )
 
     print(f"Successfully uploaded to {args.output}")
 

--- a/code/run
+++ b/code/run
@@ -22,14 +22,31 @@ fi
 SUBJECT_ID=$(echo "$RAW_DATA_ASSET" | grep -oP 'exaSPIM_\K[^_]+')
 echo "Parsed subject ID: ${SUBJECT_ID}"
 
+NMCP_BASE_URL="${NMCP_BASE_URL:-https://morphology.allenneuraldynamics.org}"
+echo "Using NMCP base URL: ${NMCP_BASE_URL}"
+
 BASE_DIR="/results"
 CCF_SPACE_DIR="$BASE_DIR/ccf_space_reconstructions"
 SPECIMEN_SPACE_DIR="$BASE_DIR/specimen_space_reconstructions"
+PORTAL_JSON_TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/nmcp-portal-json.XXXXXX")
+CCF_PORTAL_JSON_DIR="$PORTAL_JSON_TMP_DIR/ccf_space_reconstructions/json"
+SPECIMEN_PORTAL_JSON_DIR="$PORTAL_JSON_TMP_DIR/specimen_space_reconstructions/json"
 
-mkdir -p "$CCF_SPACE_DIR" "$SPECIMEN_SPACE_DIR"
+cleanup() {
+  rm -rf "$PORTAL_JSON_TMP_DIR"
+}
+
+trap cleanup EXIT
+
+mkdir -p \
+  "$CCF_SPACE_DIR" \
+  "$SPECIMEN_SPACE_DIR" \
+  "$CCF_PORTAL_JSON_DIR" \
+  "$SPECIMEN_PORTAL_JSON_DIR"
 
 echo "Downloading CCF space JSONs for subject ${SUBJECT_ID}..."
 python reconstruction_snapshot/download_neurons.py \
+  --url "$NMCP_BASE_URL" \
   --format json \
   --output "$CCF_SPACE_DIR/json" \
   --subject "$SUBJECT_ID" \
@@ -38,6 +55,7 @@ python reconstruction_snapshot/download_neurons.py \
 
 echo "Downloading CCF space SWCs for subject ${SUBJECT_ID}..."
 python reconstruction_snapshot/download_neurons.py \
+  --url "$NMCP_BASE_URL" \
   --format swc \
   --output "$CCF_SPACE_DIR/swc" \
   --subject "$SUBJECT_ID" \
@@ -46,6 +64,7 @@ python reconstruction_snapshot/download_neurons.py \
 
 echo "Downloading specimen space JSONs for subject ${SUBJECT_ID}..."
 python reconstruction_snapshot/download_neurons.py \
+  --url "$NMCP_BASE_URL" \
   --format json \
   --output "$SPECIMEN_SPACE_DIR/json" \
   --subject "$SUBJECT_ID" \
@@ -54,20 +73,39 @@ python reconstruction_snapshot/download_neurons.py \
 
 echo "Downloading specimen space SWCs for subject ${SUBJECT_ID}..."
 python reconstruction_snapshot/download_neurons.py \
+  --url "$NMCP_BASE_URL" \
   --format swc \
   --output "$SPECIMEN_SPACE_DIR/swc" \
   --subject "$SUBJECT_ID" \
   --reconstruction-space specimen \
   --verbose
 
+echo "Downloading temporary CCF portal JSONs for precomputed generation..."
+python reconstruction_snapshot/download_neurons.py \
+  --url "$NMCP_BASE_URL" \
+  --format portal-json \
+  --output "$CCF_PORTAL_JSON_DIR" \
+  --subject "$SUBJECT_ID" \
+  --reconstruction-space ccf \
+  --verbose
+
+echo "Downloading temporary specimen portal JSONs for precomputed generation..."
+python reconstruction_snapshot/download_neurons.py \
+  --url "$NMCP_BASE_URL" \
+  --format portal-json \
+  --output "$SPECIMEN_PORTAL_JSON_DIR" \
+  --subject "$SUBJECT_ID" \
+  --reconstruction-space specimen \
+  --verbose
+
 echo "Generating precomputed file for CCF reconstructions..."
 python reconstruction_snapshot/write_precomputed.py \
-  --input-dir "$CCF_SPACE_DIR/json" \
+  --input-dir "$CCF_PORTAL_JSON_DIR" \
   --output "$CCF_SPACE_DIR/reconstructions.precomputed"
 
 echo "Generating precomputed file for specimen space reconstructions..."
 python reconstruction_snapshot/write_precomputed.py \
-  --input-dir "$SPECIMEN_SPACE_DIR/json" \
+  --input-dir "$SPECIMEN_PORTAL_JSON_DIR" \
   --output "$SPECIMEN_SPACE_DIR/reconstructions.precomputed" \
   --zarr-group "$FUSED_ZARR_PATH"
 

--- a/environment/postInstall
+++ b/environment/postInstall
@@ -16,10 +16,10 @@ xlrd==2.0.2 \
 smartsheet-python-sdk==3.7.2 \
 boto3==1.40.49 \
 aind-data-schema==2.6.0 \
-matplotlib==3.10.7
+matplotlib==3.10.7 \
+cloud-volume==12.12.1
 
-# latest allensdk must be installed before nmcp-precomputed to avoid installation error with py3.12
 pip3 install -e "git+https://github.com/AllenInstitute/AllenSDK@1bdca3ad884c3a5edea8236161424650603e6f29#egg=allensdk"
-pip3 install -e "git+https://github.com/AllenNeuralDynamics/nmcp-precomputed@v3.0.3#egg=nmcp"
+pip3 install nmcp-precomputed==3.0.7
 
 echo "All done!"


### PR DESCRIPTION
This pull request updates the workflow for generating and publishing exaSPIM subject reconstruction snapshots, with a major focus on supporting and staging "portal-format" JSON reconstructions for Neuroglancer precomputed skeleton generation. It also improves CLI flexibility, enhances argument parsing, and clarifies documentation. The most important changes are grouped below:

**Support for Portal-Format JSON Reconstructions:**

* The workflow now downloads and stages portal-format JSON reconstructions (in addition to legacy JSON and SWC) for both CCF and specimen spaces, using them as the source for precomputed skeleton generation. These portal-format JSONs are stored temporarily and deleted after use. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R68-R71) [[3]](diffhunk://#diff-bb992c1bd4bd55edfb25ac4ddf4ad2d30bf6fe52e63571e8f089aa049ba5a7d3R25-R49)
* The `write_precomputed.py` script is refactored to consume portal-format JSON files, with stricter validation and a new scaling implementation that operates on the `nodes` list of portal reconstructions. [[1]](diffhunk://#diff-513d166493afdcc60db471ffe9e35ec63d3d8dbf322c138cb5733b93244e5ec2L100-R162) [[2]](diffhunk://#diff-513d166493afdcc60db471ffe9e35ec63d3d8dbf322c138cb5733b93244e5ec2L178-R229)

**Refactoring and Improvements to Argument Parsing:**

* Export format and reconstruction space CLI arguments now support stable, user-friendly aliases (e.g., `json`, `legacy-json`, `portal-json`, `swc`, `specimen`, `atlas`, `ccf`), with robust parsing logic consolidated in `enums.py`. [[1]](diffhunk://#diff-1e223876be47af9446dd24d445262fd71244438d61b3ba6cf8570acb62c205a7L3-R64) [[2]](diffhunk://#diff-e8af3dff3b76ed7f44ede65c001153ffaea30ba891540e9304aa0466d4ddcb0dL109-R125) [[3]](diffhunk://#diff-e8af3dff3b76ed7f44ede65c001153ffaea30ba891540e9304aa0466d4ddcb0dL153-R156)
* Default export format is now explicitly set to `legacy-json` for backward compatibility.

**Workflow and Environment Variable Updates:**

* The NMCP base URL is now configurable via the `NMCP_BASE_URL` environment variable, defaulting to the Allen Neural Dynamics portal instance. This is reflected in both documentation and the main workflow script. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R29) [[2]](diffhunk://#diff-bb992c1bd4bd55edfb25ac4ddf4ad2d30bf6fe52e63571e8f089aa049ba5a7d3R25-R49)

**Documentation and Usability:**

* The `README.md` is updated to clarify the new workflow, including the handling of portal-format JSONs, environment variables, and notes on legacy versus portal-format outputs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L8-R11) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R29) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R68-R71)
* CLI help strings and error messages are improved for clarity and user guidance. [[1]](diffhunk://#diff-e8af3dff3b76ed7f44ede65c001153ffaea30ba891540e9304aa0466d4ddcb0dL153-R156) [[2]](diffhunk://#diff-1e223876be47af9446dd24d445262fd71244438d61b3ba6cf8570acb62c205a7L3-R64)

**Internal Codebase Improvements:**

* Functions and type signatures are refactored for clarity, robustness, and maintainability, especially in the handling of JSON downloads and precomputed skeleton generation. [[1]](diffhunk://#diff-513d166493afdcc60db471ffe9e35ec63d3d8dbf322c138cb5733b93244e5ec2L2-R13) [[2]](diffhunk://#diff-e8af3dff3b76ed7f44ede65c001153ffaea30ba891540e9304aa0466d4ddcb0dR5-R14) [[3]](diffhunk://#diff-73a06c3f826980f6f44b060effed0fc82aa31a16a2c9dd78986ab3543d227776R175) [[4]](diffhunk://#diff-73a06c3f826980f6f44b060effed0fc82aa31a16a2c9dd78986ab3543d227776R193-R200)

These changes ensure the workflow is compatible with both legacy and new portal data formats, improve usability for end users, and set the stage for future migration to portal-format reconstructions.